### PR TITLE
[Fix]: Send stringified raw data to Alexa APIs

### DIFF
--- a/ask-sdk-core/ask_sdk_core/api_client.py
+++ b/ask-sdk-core/ask_sdk_core/api_client.py
@@ -18,6 +18,7 @@
 import typing
 import requests
 import six
+import json
 
 from urllib3.util import parse_url
 
@@ -65,8 +66,9 @@ class DefaultApiClient(ApiClient):
                 raise ApiClientException(
                     "Requests against non-HTTPS endpoints are not allowed.")
 
+            raw_data = json.dumps(request.body)
             http_response = http_method(
-                url=request.url, headers=http_headers, data=request.body)
+                url=request.url, headers=http_headers, data=raw_data)
 
             return ApiClientResponse(
                 headers=self._convert_dict_to_list_tuples(

--- a/ask-sdk-core/tests/unit/test_api_client.py
+++ b/ask-sdk-core/tests/unit/test_api_client.py
@@ -16,6 +16,7 @@
 # License.
 #
 import unittest
+import json
 from six import PY3
 
 from ask_sdk_model.services import ApiClientRequest
@@ -183,3 +184,17 @@ class TestDefaultApiClient(unittest.TestCase):
                 self.test_api_client.invoke(test_invalid_url_scheme_request)
 
             assert "Requests against non-HTTPS endpoints are not allowed." in str(exc.exception)
+
+    def test_api_client_send_request_with_raw_data(self):
+        test_data = "test\nstring"
+        self.valid_request.body = "test\nstring"
+        self.valid_request.method = "POST"
+
+        with mock.patch(
+                "requests.post",
+                side_effect=lambda *args, **kwargs: self.valid_mock_response
+        ) as mock_put:
+            actual_response = self.test_api_client.invoke(self.valid_request)
+            mock_put.assert_called_once_with(
+                data=json.dumps(test_data), headers={},
+                url=self.valid_request.url)


### PR DESCRIPTION
This commit changes the data from request body to raw data using
json dumps method, so that the ``requests`` library uses the
stringified raw data for requests.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Fixes #11 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->
Added sample test case that stringifies the request data before calling the API. Tested a sample progressive response skill using the following code sample on Python 2.7 with ask-sdk installed: 

```
    from ask_sdk_core.handler_input import HandlerInput
    from ask_sdk_model.services.directive import (
        SendDirectiveRequest, Header, SpeakDirective)
     
    def call_directive_service(handler_input):
        # type: (HandlerInput) -> None
        request_id_holder = handler_input.request_envelope.request.request_id
        directive_header = Header(request_id=request_id_holder)
        speech = SpeakDirective(speech="Ok, give me a minute")
        s = SendDirectiveRequest(header=directive_header, directive=speech)
     
        handler_input.service_client_factory.get_directive_service().enqueue(s)
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa-labs/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
