### PR TITLE
Remove inspect.getargspec from sb decorators

### DIFF
--- a/ask-sdk-core/ask_sdk_core/skill_builder.py
+++ b/ask-sdk-core/ask_sdk_core/skill_builder.py
@@ -16,7 +16,6 @@
 # License.
 #
 import json
-import inspect
 import typing
 
 from ask_sdk_model import RequestEnvelope
@@ -215,22 +214,6 @@ class SkillBuilder(object):
                     "Request Handler can_handle_func and handle_func "
                     "input parameters should be callable")
 
-            can_handle_arg_spec = inspect.getargspec(can_handle_func)
-            if (len(can_handle_arg_spec.args) != 1 or
-                    can_handle_arg_spec.varargs is not None or
-                    can_handle_arg_spec.keywords is not None):
-                raise SkillBuilderException(
-                    "Request Handler can_handle_func should only accept a "
-                    "single input arg, handler input")
-
-            handle_arg_spec = inspect.getargspec(handle_func)
-            if (len(handle_arg_spec.args) != 1 or
-                    handle_arg_spec.varargs is not None or
-                    handle_arg_spec.keywords is not None):
-                raise SkillBuilderException(
-                    "Request Handler handle_func should only accept a single "
-                    "input arg, handler input")
-
             class_attributes = {
                 "can_handle": lambda self, handler_input: can_handle_func(
                     handler_input),
@@ -273,22 +256,6 @@ class SkillBuilder(object):
                     "Exception Handler can_handle_func and handle_func input "
                     "parameters should be callable")
 
-            can_handle_arg_spec = inspect.getargspec(can_handle_func)
-            if (len(can_handle_arg_spec.args) != 2 or
-                    can_handle_arg_spec.varargs is not None or
-                    can_handle_arg_spec.keywords is not None):
-                raise SkillBuilderException(
-                    "Exception Handler can_handle_func should only accept "
-                    "two input args, handler input and exception")
-
-            handle_arg_spec = inspect.getargspec(handle_func)
-            if (len(handle_arg_spec.args) != 2 or
-                    handle_arg_spec.varargs is not None or
-                    handle_arg_spec.keywords is not None):
-                raise SkillBuilderException(
-                    "Exception Handler handle_func should only accept two "
-                    "input args, handler input and exception")
-
             class_attributes = {
                 "can_handle": (
                     lambda self, handler_input, exception: can_handle_func(
@@ -326,14 +293,6 @@ class SkillBuilder(object):
                     "Global Request Interceptor process_func input parameter "
                     "should be callable")
 
-            process_arg_spec = inspect.getargspec(process_func)
-            if (len(process_arg_spec.args) != 1 or
-                    process_arg_spec.varargs is not None or
-                    process_arg_spec.keywords is not None):
-                raise SkillBuilderException(
-                    "Global Request Interceptor process_func should only "
-                    "accept a single input arg, handler input")
-
             class_attributes = {
                 "process": lambda self, handler_input: process_func(
                     handler_input)
@@ -368,14 +327,6 @@ class SkillBuilder(object):
                 raise SkillBuilderException(
                     "Global Response Interceptor process_func input "
                     "parameter should be callable")
-
-            process_arg_spec = inspect.getargspec(process_func)
-            if (len(process_arg_spec.args) != 2 or
-                    process_arg_spec.varargs is not None or
-                    process_arg_spec.keywords is not None):
-                raise SkillBuilderException(
-                    "Global Response Interceptor process_func should only "
-                    "accept two input args, handler input and response")
 
             class_attributes = {
                 "process": (

--- a/ask-sdk-core/tests/unit/test_skill_builder.py
+++ b/ask-sdk-core/tests/unit/test_skill_builder.py
@@ -370,36 +370,6 @@ class TestSkillBuilder(unittest.TestCase):
             "Request Handler decorator created Request Handler with incorrect "
             "handle function")
 
-    def test_request_handler_decorator_on_can_handle_func_with_incorrect_params(self):
-        def test_can_handle():
-            return True
-
-        def test_handle(input):
-            return "something"
-
-        with self.assertRaises(SkillBuilderException) as exc:
-            self.sb.request_handler(can_handle_func=test_can_handle)(
-                handle_func=test_handle)
-
-        assert "can_handle_func should only accept a single input arg, handler input" in str(exc.exception), (
-            "Request Handler Decorator accepted invalid can_handle_func "
-            "parameter")
-
-    def test_request_handler_decorator_on_handle_func_with_incorrect_params(self):
-        def test_can_handle(input):
-            return True
-
-        def test_handle(*args, **kwargs):
-            return "something"
-
-        with self.assertRaises(SkillBuilderException) as exc:
-            self.sb.request_handler(can_handle_func=test_can_handle)(
-                handle_func=test_handle)
-
-        assert "handle_func should only accept a single input arg, handler input" in str(exc.exception), (
-            "Request Handler Decorator was decorated with invalid "
-            "handle_func which takes more than one input args")
-
     def test_exception_handler_decorator_creation(self):
         exception_handler_wrapper = self.sb.exception_handler(
             can_handle_func=None)
@@ -457,36 +427,6 @@ class TestSkillBuilder(unittest.TestCase):
             "Exception Handler decorator created Exception Handler with "
             "incorrect handle function")
 
-    def test_exception_handler_decorator_on_can_handle_func_with_incorrect_params(self):
-        def test_can_handle(*args):
-            return True
-
-        def test_handle(input, exc):
-            return "something"
-
-        with self.assertRaises(SkillBuilderException) as exc:
-            self.sb.exception_handler(can_handle_func=test_can_handle)(
-                handle_func=test_handle)
-
-        assert "can_handle_func should only accept two input args, handler input and exception" in str(exc.exception), (
-            "Exception Handler Decorator accepted invalid can_handle_func "
-            "parameter")
-
-    def test_exception_handler_decorator_on_handle_func_with_incorrect_params(self):
-        def test_can_handle(input, exc):
-            return True
-
-        def test_handle(exc, **kwargs):
-            return "something"
-
-        with self.assertRaises(SkillBuilderException) as exc:
-            self.sb.exception_handler(can_handle_func=test_can_handle)(
-                handle_func=test_handle)
-
-        assert "handle_func should only accept two input args, handler input and exception" in str(exc.exception), (
-            "Exception Handler Decorator was decorated with invalid "
-            "handle_func which takes more than two input args")
-
     def test_global_request_interceptor_decorator_creation(self):
         request_interceptor_wrapper = self.sb.global_request_interceptor()
         assert callable(request_interceptor_wrapper), (
@@ -521,18 +461,6 @@ class TestSkillBuilder(unittest.TestCase):
 
         assert actual_global_request_interceptor.__class__.__name__ == "RequestInterceptorTestProcess"
         assert actual_global_request_interceptor.process(None) == "something"
-
-    def test_global_request_interceptor_on_process_func_with_incorrect_params(self):
-        def test_process(**kwargs):
-            return "something"
-
-        with self.assertRaises(SkillBuilderException) as exc:
-            self.sb.global_request_interceptor()(process_func=test_process)
-
-        assert "process_func should only accept a single input arg, handler input" in str(exc.exception), (
-            "Global Request Interceptor Decorator was decorated with invalid "
-            "process_func which takes more than "
-            "one input args")
 
     def test_global_response_interceptor_decorator_creation(self):
         response_interceptor_wrapper = self.sb.global_response_interceptor()
@@ -571,18 +499,6 @@ class TestSkillBuilder(unittest.TestCase):
 
         assert actual_global_response_interceptor.__class__.__name__ == "ResponseInterceptorTestProcess"
         assert actual_global_response_interceptor.process(None, None) == "something"
-
-    def test_global_response_interceptor_on_process_func_with_incorrect_params(self):
-        def test_process(**kwargs):
-            return "something"
-
-        with self.assertRaises(SkillBuilderException) as exc:
-            self.sb.global_response_interceptor()(process_func=test_process)
-
-        assert "process_func should only accept two input args, handler input and response" in str(exc.exception), (
-            "Global Response Interceptor Decorator was decorated with invalid "
-            "process_func which takes more than "
-            "one input args")
 
 
 class TestCustomSkillBuilder(unittest.TestCase):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This commit removes the strict check of having corresponding
arguments passed in the decorated functions (request_handler,
exception_handler, global_request_interceptor,
global_response_interceptor), which was surfaced as part of
using type annotations in Python 3.x (Issue #20).

The ``inspect.getargspec`` function usage is being deprecated in
Python 3 and without these checks, the default error message thrown
to the user is good enough to debug.

Fixes #20.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Issue #20

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->
Ran unit tests through ``scripts/ci/run_tests`` on the SDK installed using ``scripts/ci/sdk_install``

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa-labs/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
