### PR TITLE
Enable consistent reads through DynamoDb adapter

### DIFF
--- a/ask-sdk-dynamodb-persistence-adapter/ask_sdk_dynamodb/adapter.py
+++ b/ask-sdk-dynamodb-persistence-adapter/ask_sdk_dynamodb/adapter.py
@@ -123,7 +123,8 @@ class DynamoDbAdapter(AbstractPersistenceAdapter):
             table = self.dynamodb.Table(self.table_name)
             partition_key_val = self.partition_keygen(request_envelope)
             response = table.get_item(
-                Key={self.partition_key_name: partition_key_val})
+                Key={self.partition_key_name: partition_key_val},
+                ConsistentRead=True)
             if "Item" in response:
                 return response["Item"][self.attribute_name]
             else:

--- a/ask-sdk-dynamodb-persistence-adapter/tests/unit/test_adapter.py
+++ b/ask-sdk-dynamodb-persistence-adapter/tests/unit/test_adapter.py
@@ -65,7 +65,7 @@ class TestDynamoDbAdapter(unittest.TestCase):
             "Partition Keygen provided incorrect input parameters during get "
             "attributes call")
         mock_table.get_item.assert_called_once_with(
-            Key={"id": "test_partition_key"}), (
+            Key={"id": "test_partition_key"}, ConsistentRead=True), (
             "Partition keygen provided incorrect key for get attributes call")
 
     def test_get_attributes_from_existing_table_custom_key_name_attribute_name(self):
@@ -92,7 +92,7 @@ class TestDynamoDbAdapter(unittest.TestCase):
             "Partition Keygen provided incorrect input parameters during get "
             "item call")
         mock_table.get_item.assert_called_once_with(
-            Key={"custom_key": "test_partition_key"}), (
+            Key={"custom_key": "test_partition_key"}, ConsistentRead=True), (
             "Partition keygen provided incorrect key for get attributes call")
 
     def test_get_attributes_from_existing_table_get_item_fails(self):
@@ -114,7 +114,7 @@ class TestDynamoDbAdapter(unittest.TestCase):
             "Get attributes didn't raise Persistence Exception when get item "
             "failed on dynamodb resource")
         mock_table.get_item.assert_called_once_with(
-            Key={"id": "test_partition_key"}), (
+            Key={"id": "test_partition_key"}, ConsistentRead=True), (
             "Partition keygen provided incorrect key for get attributes call")
 
     def test_get_attributes_from_existing_table_get_item_returns_no_item(self):


### PR DESCRIPTION
Enable consistent reads for the get_attributes method from DynamoDB Adapter. This makes the reads consistent if the user is reading the attributes immediately after a ``save``.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa-labs/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
